### PR TITLE
Add tabulateFix' and memoizeFix'

### DIFF
--- a/test/Test.hs
+++ b/test/Test.hs
@@ -73,11 +73,18 @@ chimeraTests = testGroup "Chimera"
     \(Fun _ (f :: Word -> Bool)) ix ->
       let jx = ix `mod` 65536 in
         f jx === Ch.index (Ch.tabulate f :: Ch.Chimera U.Vector Bool) jx
+
   , QC.testProperty "index . tabulateFix = fix" $
     \(Fun _ g) ix ->
       let jx = ix `mod` 65536 in
         let f = mkUnfix g in
           fix f jx === Ch.index (Ch.tabulateFix f :: Ch.Chimera U.Vector Bool) jx
+
+  , QC.testProperty "index . tabulateFix' = fix" $
+    \(Fun _ g) ix ->
+      let jx = ix `mod` 65536 in
+        let f = mkUnfix g in
+          fix f jx === Ch.index (Ch.tabulateFix' f :: Ch.Chimera U.Vector Bool) jx
 
   , QC.testProperty "iterate" $
     \(Fun _ (f :: Word -> Word)) seed ix ->


### PR DESCRIPTION
Add fully memoizing versions of tabulateFix and memoizeFix (fixes #18).
Also fixes an integer overflow when left shifting 1 by a total of 64 when creating the very last vector of size 2^63.