### PR TITLE
Add "and applications for memoization" to cabal file synopsis

### DIFF
--- a/chimera.cabal
+++ b/chimera.cabal
@@ -8,7 +8,7 @@ copyright: 2017-2019 Bodigrim
 maintainer: andrew.lelechenko@gmail.com
 homepage: https://github.com/Bodigrim/chimera#readme
 category: Data
-synopsis: Lazy infinite streams with O(1) indexing
+synopsis: Lazy infinite streams with O(1) indexing and applications for memoization
 author: Bodigrim
 extra-source-files:
   README.md


### PR DESCRIPTION
I search libraries by going to http://hackage.haskell.org/packages and grepping for keywords, and including "memoiz" would have helped me find this lib