### PR TITLE
Fix `fromInfinite` error

### DIFF
--- a/chimera.cabal
+++ b/chimera.cabal
@@ -95,6 +95,7 @@ test-suite chimera-test
     build-depends:
         base >=4.5 && <5,
         chimera,
+        infinite-list,
         QuickCheck >=2.10 && <2.15,
         tasty <1.6,
         tasty-hunit <0.11,

--- a/src/Data/Chimera/Internal.hs
+++ b/src/Data/Chimera/Internal.hs
@@ -572,7 +572,10 @@ fromInfinite = Chimera . fromListN (bits + 1) . go0
   where
     go0 (x :< xs) = G.singleton x : go 0 xs
 
-    go k xs = G.fromListN kk ys : go (k + 1) zs
+    go k xs =
+      if k == bits
+        then []
+        else G.fromListN kk ys : go (k + 1) zs
       where
         kk = 1 `shiftL` k
         (ys, zs) = Inf.splitAt kk xs

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -12,7 +12,9 @@ import Test.Tasty.QuickCheck as QC hiding ((.&.))
 import Data.Bits
 import Data.Foldable
 import Data.Function (fix)
+import qualified Data.List.Infinite as I
 import qualified Data.List as L
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Vector.Generic as G
 
 import Data.Chimera.ContinuousMapping
@@ -157,6 +159,13 @@ chimeraTests = testGroup "Chimera"
       let jx = ix `mod` 65536 in
         (if fromIntegral jx < length xs then xs !! fromIntegral jx else x) ===
           Ch.index (Ch.fromListWithDef x xs :: UChimera Bool) jx
+
+  , QC.testProperty "fromInfinite" $
+    \x xs ix ->
+      let jx = ix `mod` 65536 in
+        let ys = I.cycle (x NE.:| xs) in
+          (ys I.!! jx) ===
+            Ch.index (Ch.fromInfinite ys :: UChimera Bool) jx
 
   , QC.testProperty "fromVectorWithDef" $
     \x xs ix ->


### PR DESCRIPTION
In the implementation of `fromInfinite`, we pass an infinite list to `Data.Primitive.Array.fromListN (bits + 1)`, but `fromListN` expects a list a list of length `bits + 1`, which results in a runtime error.

~~To fix this, we take the first `bits + 1` of the infinite list before passing to `fromListN`.~~

Updated solution: To fix this, we add a check in `go` to break recursion and to ensure that the list that is passed into `fromListN` has length `bits + 1`.

---

Fixes issue https://github.com/Bodigrim/chimera/issues/40